### PR TITLE
fix: Expand color regex range

### DIFF
--- a/src/abide.js
+++ b/src/abide.js
@@ -690,7 +690,7 @@ Abide.defaults = {
     day_month_year: /^(0[1-9]|[12][0-9]|3[01])[- \\/.](0[1-9]|1[012])[- \\/.]\d{4}$/,
 
     // #FFF or #FFFFFF
-    color: /^#?([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/,
+    color: /^(#[0-9a-f-A-F]{3}|#(?:[0-9a-f-A-F]{2}){2,4}|(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\))$/,
 
     // Domain || URL
     website: {


### PR DESCRIPTION
This PR will close #2 and:
- Expand the color regex range to allow more CSS color definitions