### PR TITLE
Replace filter method by map

### DIFF
--- a/src/abide.js
+++ b/src/abide.js
@@ -221,7 +221,7 @@ class Abide {
    * @returns {Boolean} Boolean value depends on whether or not attribute is checked or empty
    */
   findRadioLabels(elements) {
-    const labels = elements.filter((element) => {
+    const labels = elements.map((element) => {
       const {
         id,
       } = element;

--- a/test/abide.test.js
+++ b/test/abide.test.js
@@ -171,7 +171,7 @@ describe('Abide', () => {
 
   describe('removeRadioErrorClasses()', () => {
     it('removes aria-invalid attribute from radio group', () => {
-      htmlString = '<form data-abide><input type="radio" name="groupName"></form>';
+      htmlString = '<form data-abide><input type="radio" name="groupName" id="test"><label for="test">Hello World</label></form>';
       document.querySelector('body').insertAdjacentHTML('beforeend', htmlString);
       myForm = document.querySelector('form');
       plugin = new Abide(myForm);


### PR DESCRIPTION
Hey,

Thank you for your great vanilla package :) I've found small fix on your `findRadioLabels` method : 

`const labels = elements.filter();` return always Array element, not the `label` wanted.

I've replace `filter()` by `map()`, all labels are return :muscle: 